### PR TITLE
Add screenshot ingestion, vision enrichment, and timeline linking pipeline

### DIFF
--- a/apps/api/src/__tests__/server.test.ts
+++ b/apps/api/src/__tests__/server.test.ts
@@ -1,24 +1,21 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Fastify, { FastifyInstance } from 'fastify';
-import type { Insight, ScreenshotEvent, TimelineEntry, VoiceCaptureSession } from '@daily-timeline/types';
+import type { Insight, TimelineEntry, VoiceCaptureSession } from '@daily-timeline/types';
+import { registerScreenshotRoutes } from '../services/screenshots/routes';
+import { InMemoryScreenshotStorage } from '../services/screenshots/storage';
 
-/**
- * Build a Fastify app with the same routes as server.ts, but without the
- * module-level side effects (readConfig(process.env) and server.listen()).
- * This mirrors exactly the routes defined in apps/api/src/server.ts.
- */
 function buildApp(): FastifyInstance {
   const app = Fastify({ logger: false });
 
   const timelineEntries: TimelineEntry[] = [];
   const voiceSessions: VoiceCaptureSession[] = [];
-  const screenshotEvents: ScreenshotEvent[] = [];
   const insights: Insight[] = [];
+  const screenshotStorage = new InMemoryScreenshotStorage();
 
   app.get('/health', async () => ({ ok: true, service: 'daily-timeline-api' }));
   app.get('/timeline/entries', async () => ({ data: timelineEntries }));
   app.get('/voice/sessions', async () => ({ data: voiceSessions }));
-  app.get('/screenshots/events', async () => ({ data: screenshotEvents }));
+  registerScreenshotRoutes(app, { storage: screenshotStorage, timelineEntries, insights });
   app.get('/insights', async () => ({ data: insights }));
 
   return app;
@@ -36,116 +33,54 @@ describe('API server routes', () => {
     await app.close();
   });
 
-  describe('GET /health', () => {
-    it('returns 200 with ok: true and service name', async () => {
-      const response = await app.inject({ method: 'GET', url: '/health' });
-
-      expect(response.statusCode).toBe(200);
-      const body = response.json();
-      expect(body).toEqual({ ok: true, service: 'daily-timeline-api' });
-    });
-
-    it('returns JSON content-type', async () => {
-      const response = await app.inject({ method: 'GET', url: '/health' });
-
-      expect(response.headers['content-type']).toMatch(/application\/json/);
-    });
+  it('GET /health returns service status', async () => {
+    const response = await app.inject({ method: 'GET', url: '/health' });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ ok: true, service: 'daily-timeline-api' });
   });
 
-  describe('GET /timeline/entries', () => {
-    it('returns 200 with empty data array', async () => {
-      const response = await app.inject({ method: 'GET', url: '/timeline/entries' });
-
-      expect(response.statusCode).toBe(200);
-      const body = response.json();
-      expect(body).toEqual({ data: [] });
-    });
-
-    it('data field is an array', async () => {
-      const response = await app.inject({ method: 'GET', url: '/timeline/entries' });
-
-      const body = response.json();
-      expect(Array.isArray(body.data)).toBe(true);
-    });
+  it('GET /screenshots/events returns array shape', async () => {
+    const response = await app.inject({ method: 'GET', url: '/screenshots/events' });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ data: [] });
   });
 
-  describe('GET /voice/sessions', () => {
-    it('returns 200 with empty data array', async () => {
-      const response = await app.inject({ method: 'GET', url: '/voice/sessions' });
-
-      expect(response.statusCode).toBe(200);
-      const body = response.json();
-      expect(body).toEqual({ data: [] });
+  it('POST /screenshots/events stores enriched screenshot event and creates timeline entry', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/screenshots/events',
+      payload: {
+        imageUrl: 'https://storage.example.com/editor-error-warning.png',
+        capturedAt: '2024-01-15T09:00:00.000Z',
+        windowTitle: 'VSCode deploy warning',
+        hintedText: 'TODO fix deploy error before review',
+      },
     });
 
-    it('data field is an array', async () => {
-      const response = await app.inject({ method: 'GET', url: '/voice/sessions' });
+    expect(response.statusCode).toBe(201);
+    const body = response.json();
+    expect(body.data.imageUrl).toContain('editor-error-warning');
+    expect(body.data.taskClues).toContain('todo');
+    expect(body.data.anomalies).toContain('error');
 
-      const body = response.json();
-      expect(Array.isArray(body.data)).toBe(true);
-    });
+    const listResponse = await app.inject({ method: 'GET', url: '/screenshots/events' });
+    expect(listResponse.json().data).toHaveLength(1);
+
+    const timelineResponse = await app.inject({ method: 'GET', url: '/timeline/entries' });
+    expect(timelineResponse.json().data).toHaveLength(1);
+
+    const insightResponse = await app.inject({ method: 'GET', url: '/insights' });
+    expect(insightResponse.json().data).toHaveLength(1);
+    expect(insightResponse.json().data[0].summary).toContain('Possible missed detail');
   });
 
-  describe('GET /screenshots/events', () => {
-    it('returns 200 with empty data array', async () => {
-      const response = await app.inject({ method: 'GET', url: '/screenshots/events' });
-
-      expect(response.statusCode).toBe(200);
-      const body = response.json();
-      expect(body).toEqual({ data: [] });
+  it('POST /screenshots/events validates payload', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/screenshots/events',
+      payload: { imageUrl: 'not-a-url' },
     });
 
-    it('data field is an array', async () => {
-      const response = await app.inject({ method: 'GET', url: '/screenshots/events' });
-
-      const body = response.json();
-      expect(Array.isArray(body.data)).toBe(true);
-    });
-  });
-
-  describe('GET /insights', () => {
-    it('returns 200 with empty data array', async () => {
-      const response = await app.inject({ method: 'GET', url: '/insights' });
-
-      expect(response.statusCode).toBe(200);
-      const body = response.json();
-      expect(body).toEqual({ data: [] });
-    });
-
-    it('data field is an array', async () => {
-      const response = await app.inject({ method: 'GET', url: '/insights' });
-
-      const body = response.json();
-      expect(Array.isArray(body.data)).toBe(true);
-    });
-  });
-
-  describe('unknown routes', () => {
-    it('returns 404 for an unregistered route', async () => {
-      const response = await app.inject({ method: 'GET', url: '/unknown-route' });
-
-      expect(response.statusCode).toBe(404);
-    });
-
-    it('returns 404 for POST to a GET-only endpoint', async () => {
-      const response = await app.inject({ method: 'POST', url: '/health' });
-
-      expect(response.statusCode).toBe(404);
-    });
-  });
-
-  describe('response shape consistency', () => {
-    it('all list endpoints share the same { data: [] } shape when empty', async () => {
-      const endpoints = ['/timeline/entries', '/voice/sessions', '/screenshots/events', '/insights'];
-
-      for (const endpoint of endpoints) {
-        const response = await app.inject({ method: 'GET', url: endpoint });
-        expect(response.statusCode).toBe(200);
-        const body = response.json();
-        expect(body).toHaveProperty('data');
-        expect(Array.isArray(body.data)).toBe(true);
-        expect(body.data).toHaveLength(0);
-      }
-    });
+    expect(response.statusCode).toBe(400);
   });
 });

--- a/apps/api/src/__tests__/server.test.ts
+++ b/apps/api/src/__tests__/server.test.ts
@@ -83,4 +83,77 @@ describe('API server routes', () => {
 
     expect(response.statusCode).toBe(400);
   });
+
+  it('POST /screenshots/events returns 400 with error details when userId is missing', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/screenshots/events',
+      payload: {
+        imageUrl: 'https://storage.example.com/screenshot.png',
+        capturedAt: '2024-01-15T09:00:00.000Z',
+        // userId intentionally omitted
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = response.json();
+    expect(body).toHaveProperty('error');
+    expect(body).toHaveProperty('details');
+  });
+
+  it('multiple POST /screenshots/events accumulate in the list', async () => {
+    const payload = (title: string) => ({
+      imageUrl: `https://storage.example.com/${title}.png`,
+      capturedAt: '2024-01-15T09:00:00.000Z',
+      windowTitle: title,
+      userId: 'user-1',
+    });
+
+    await app.inject({ method: 'POST', url: '/screenshots/events', payload: payload('first-shot') });
+    await app.inject({ method: 'POST', url: '/screenshots/events', payload: payload('second-shot') });
+
+    const listResponse = await app.inject({ method: 'GET', url: '/screenshots/events' });
+    expect(listResponse.json().data).toHaveLength(2);
+  });
+
+  it('GET /timeline/entries returns empty data array initially', async () => {
+    const response = await app.inject({ method: 'GET', url: '/timeline/entries' });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ data: [] });
+  });
+
+  it('GET /insights returns empty data array initially', async () => {
+    const response = await app.inject({ method: 'GET', url: '/insights' });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ data: [] });
+  });
+
+  it('POST /screenshots/events does NOT create insight when no anomalies in input', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/screenshots/events',
+      payload: {
+        imageUrl: 'https://storage.example.com/clean-normal-screenshot.png',
+        capturedAt: '2024-01-15T09:00:00.000Z',
+        windowTitle: 'Normal Editor',
+        hintedText: 'just routine work session today',
+        userId: 'user-1',
+      },
+    });
+
+    expect(response.statusCode).toBe(201);
+
+    const insightResponse = await app.inject({ method: 'GET', url: '/insights' });
+    expect(insightResponse.json().data).toHaveLength(0);
+  });
+
+  it('GET /screenshots/events returns JSON content-type', async () => {
+    const response = await app.inject({ method: 'GET', url: '/screenshots/events' });
+    expect(response.headers['content-type']).toMatch(/application\/json/);
+  });
+
+  it('returns 404 for an unregistered route', async () => {
+    const response = await app.inject({ method: 'GET', url: '/unknown-route' });
+    expect(response.statusCode).toBe(404);
+  });
 });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,20 +1,22 @@
 import Fastify from 'fastify';
-import type { Insight, ScreenshotEvent, TimelineEntry, VoiceCaptureSession } from '@daily-timeline/types';
+import type { Insight, TimelineEntry, VoiceCaptureSession } from '@daily-timeline/types';
 import { readConfig } from './config';
+import { registerScreenshotRoutes } from './services/screenshots/routes';
+import { InMemoryScreenshotStorage } from './services/screenshots/storage';
 
 const config = readConfig(process.env);
 const server = Fastify({ logger: { level: config.LOG_LEVEL } });
 
 const timelineEntries: TimelineEntry[] = [];
 const voiceSessions: VoiceCaptureSession[] = [];
-const screenshotEvents: ScreenshotEvent[] = [];
 const insights: Insight[] = [];
+const screenshotStorage = new InMemoryScreenshotStorage();
 
 server.get('/health', async () => ({ ok: true, service: 'daily-timeline-api' }));
 
 server.get('/timeline/entries', async () => ({ data: timelineEntries }));
 server.get('/voice/sessions', async () => ({ data: voiceSessions }));
-server.get('/screenshots/events', async () => ({ data: screenshotEvents }));
+registerScreenshotRoutes(server, { storage: screenshotStorage, timelineEntries, insights });
 server.get('/insights', async () => ({ data: insights }));
 
 server.listen({ port: config.PORT, host: '0.0.0.0' }).catch((error) => {

--- a/apps/api/src/services/__tests__/screenshot-pipeline.test.ts
+++ b/apps/api/src/services/__tests__/screenshot-pipeline.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import type { Insight, TimelineEntry } from '@daily-timeline/types';
+import { analyzeScreenshot, extractOcrText } from '../vision';
+import { linkScreenshotToTimeline } from '../screenshots/linker';
+import { ingestScreenshotEvent } from '../screenshots/service';
+import { InMemoryScreenshotStorage } from '../screenshots/storage';
+
+describe('screenshot pipeline', () => {
+  it('extractOcrText uses hinted text first', () => {
+    const text = extractOcrText({
+      imageUrl: 'https://storage.example.com/no-content.png',
+      windowTitle: 'Editor',
+      hintedText: 'deploy warning in terminal',
+    });
+
+    expect(text).toBe('deploy warning in terminal');
+  });
+
+  it('analyzeScreenshot identifies clues and anomalies', () => {
+    const analysis = analyzeScreenshot({
+      imageUrl: 'https://storage.example.com/deploy_error.png',
+      windowTitle: 'VSCode deploy warning',
+      hintedText: 'TODO resolve error before review',
+    });
+
+    expect(analysis.taskClues).toContain('todo');
+    expect(analysis.anomalies).toContain('error');
+  });
+
+  it('ingestScreenshotEvent links to relevant timeline and emits anomaly insight', () => {
+    const timelineEntries: TimelineEntry[] = [
+      {
+        id: 'entry-1',
+        userId: 'user-1',
+        source: 'voice',
+        text: 'Finish deploy checklist and review app logs',
+        tags: ['deploy', 'review'],
+        createdAt: '2024-01-01T00:00:00.000Z',
+        occurredAt: '2024-01-01T00:00:00.000Z',
+      },
+    ];
+    const insights: Insight[] = [];
+    const storage = new InMemoryScreenshotStorage();
+
+    const event = ingestScreenshotEvent(
+      {
+        imageUrl: 'https://storage.example.com/deploy_error.png',
+        capturedAt: '2024-01-15T09:00:00.000Z',
+        windowTitle: 'Deploy warning',
+        hintedText: 'TODO deploy failed in prod',
+        userId: 'user-1',
+      },
+      { storage, timelineEntries, insights }
+    );
+
+    expect(event.linkedTimelineEntryIds).toContain('entry-1');
+    expect(storage.list()).toHaveLength(1);
+    expect(insights[0]?.summary).toContain('Possible missed detail');
+  });
+
+  it('linkScreenshotToTimeline handles empty signals', () => {
+    const ids = linkScreenshotToTimeline([], { ocrText: null, windowTitle: null, inferredTask: null });
+    expect(ids).toEqual([]);
+  });
+});

--- a/apps/api/src/services/__tests__/screenshot-pipeline.test.ts
+++ b/apps/api/src/services/__tests__/screenshot-pipeline.test.ts
@@ -62,4 +62,156 @@ describe('screenshot pipeline', () => {
     const ids = linkScreenshotToTimeline([], { ocrText: null, windowTitle: null, inferredTask: null });
     expect(ids).toEqual([]);
   });
+
+  it('ingestScreenshotEvent does NOT create an insight when there are no anomalies', () => {
+    const timelineEntries: TimelineEntry[] = [];
+    const insights: Insight[] = [];
+    const storage = new InMemoryScreenshotStorage();
+
+    ingestScreenshotEvent(
+      {
+        imageUrl: 'https://storage.example.com/clean-screenshot.png',
+        capturedAt: '2024-01-15T09:00:00.000Z',
+        windowTitle: 'Normal Editor Window',
+        hintedText: 'just a routine review session',
+        userId: 'user-1',
+      },
+      { storage, timelineEntries, insights }
+    );
+
+    // "review" is a task clue but no anomaly terms → no insight pushed
+    expect(insights).toHaveLength(0);
+  });
+
+  it('ingestScreenshotEvent adds a TimelineEntry with source "screenshot"', () => {
+    const timelineEntries: TimelineEntry[] = [];
+    const insights: Insight[] = [];
+    const storage = new InMemoryScreenshotStorage();
+
+    ingestScreenshotEvent(
+      {
+        imageUrl: 'https://storage.example.com/clean.png',
+        capturedAt: '2024-01-15T09:00:00.000Z',
+        windowTitle: null,
+        hintedText: null,
+        userId: 'user-99',
+      },
+      { storage, timelineEntries, insights }
+    );
+
+    expect(timelineEntries).toHaveLength(1);
+    expect(timelineEntries[0].source).toBe('screenshot');
+    expect(timelineEntries[0].userId).toBe('user-99');
+  });
+
+  it('ingestScreenshotEvent uses "Screenshot captured" as text fallback when ocrText and windowTitle are both null', () => {
+    const timelineEntries: TimelineEntry[] = [];
+    const insights: Insight[] = [];
+    const storage = new InMemoryScreenshotStorage();
+
+    ingestScreenshotEvent(
+      {
+        imageUrl: 'https://storage.example.com/x.png',
+        capturedAt: '2024-01-15T09:00:00.000Z',
+        userId: 'user-1',
+      },
+      { storage, timelineEntries, insights }
+    );
+
+    // URL "x.png" yields no 12-char match → ocrText null; windowTitle not provided
+    expect(timelineEntries[0].text).toBe('Screenshot captured');
+  });
+
+  it('ingestScreenshotEvent returned ScreenshotEvent always has expected shape', () => {
+    const storage = new InMemoryScreenshotStorage();
+
+    const event = ingestScreenshotEvent(
+      {
+        imageUrl: 'https://storage.example.com/deploy-error-screenshot.png',
+        capturedAt: '2024-01-15T09:00:00.000Z',
+        windowTitle: 'Deploy Terminal',
+        userId: 'user-1',
+      },
+      { storage, timelineEntries: [], insights: [] }
+    );
+
+    expect(typeof event.id).toBe('string');
+    expect(event.id).toMatch(/^shot-/);
+    expect(event.imageUrl).toBe('https://storage.example.com/deploy-error-screenshot.png');
+    expect(event.capturedAt).toBe('2024-01-15T09:00:00.000Z');
+    expect(typeof event.createdAt).toBe('string');
+    expect(Array.isArray(event.entities)).toBe(true);
+    expect(Array.isArray(event.taskClues)).toBe(true);
+    expect(Array.isArray(event.anomalies)).toBe(true);
+    expect(Array.isArray(event.linkedTimelineEntryIds)).toBe(true);
+  });
+
+  it('multiple ingestScreenshotEvent calls accumulate events in storage', () => {
+    const storage = new InMemoryScreenshotStorage();
+
+    for (let i = 0; i < 3; i++) {
+      ingestScreenshotEvent(
+        {
+          imageUrl: `https://storage.example.com/shot${i}.png`,
+          capturedAt: '2024-01-15T09:00:00.000Z',
+          userId: 'user-1',
+        },
+        { storage, timelineEntries: [], insights: [] }
+      );
+    }
+
+    expect(storage.list()).toHaveLength(3);
+  });
+
+  it('ingestScreenshotEvent TimelineEntry tags always start with "screenshot"', () => {
+    const timelineEntries: TimelineEntry[] = [];
+    const storage = new InMemoryScreenshotStorage();
+
+    ingestScreenshotEvent(
+      {
+        imageUrl: 'https://storage.example.com/deploy-error-screenshot.png',
+        capturedAt: '2024-01-15T09:00:00.000Z',
+        windowTitle: null,
+        hintedText: 'TODO deploy failed',
+        userId: 'user-1',
+      },
+      { storage, timelineEntries, insights: [] }
+    );
+
+    expect(timelineEntries[0].tags[0]).toBe('screenshot');
+    expect(timelineEntries[0].tags.length).toBeLessThanOrEqual(6);
+  });
+
+  it('anomaly insight references both linked timeline entry IDs and the new entry ID', () => {
+    const timelineEntries: TimelineEntry[] = [
+      {
+        id: 'existing-entry',
+        userId: 'user-1',
+        source: 'voice',
+        text: 'deploy review checklist',
+        tags: ['deploy', 'review'],
+        createdAt: '2024-01-01T00:00:00.000Z',
+        occurredAt: '2024-01-01T00:00:00.000Z',
+      },
+    ];
+    const insights: Insight[] = [];
+    const storage = new InMemoryScreenshotStorage();
+
+    ingestScreenshotEvent(
+      {
+        imageUrl: 'https://storage.example.com/deploy-error.png',
+        capturedAt: '2024-01-15T09:00:00.000Z',
+        windowTitle: null,
+        hintedText: 'TODO deploy failed with error',
+        userId: 'user-1',
+      },
+      { storage, timelineEntries, insights }
+    );
+
+    expect(insights).toHaveLength(1);
+    expect(insights[0].type).toBe('anomaly');
+    expect(insights[0].confidence).toBe(0.68);
+    // Should reference the linked entry and the new timeline entry
+    expect(insights[0].entryIds.length).toBeGreaterThan(0);
+  });
 });

--- a/apps/api/src/services/screenshots/__tests__/linker.test.ts
+++ b/apps/api/src/services/screenshots/__tests__/linker.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import type { TimelineEntry } from '@daily-timeline/types';
+import { linkScreenshotToTimeline } from '../linker';
+
+function makeEntry(id: string, text: string, tags: string[] = []): TimelineEntry {
+  return {
+    id,
+    userId: 'user-1',
+    source: 'voice',
+    text,
+    tags,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    occurredAt: '2024-01-01T00:00:00.000Z',
+  };
+}
+
+describe('linkScreenshotToTimeline', () => {
+  it('returns empty array when there are no timeline entries', () => {
+    const ids = linkScreenshotToTimeline([], {
+      ocrText: 'deploy error timeout',
+      windowTitle: 'Terminal',
+      inferredTask: null,
+    });
+    expect(ids).toEqual([]);
+  });
+
+  it('returns empty array when all signals are null (corpus is empty)', () => {
+    const entries = [makeEntry('e1', 'deploy failed in production')];
+    const ids = linkScreenshotToTimeline(entries, {
+      ocrText: null,
+      windowTitle: null,
+      inferredTask: null,
+    });
+    expect(ids).toEqual([]);
+  });
+
+  it('returns empty array when no entry has overlapping tokens', () => {
+    const entries = [makeEntry('e1', 'music playlist jazz')];
+    const ids = linkScreenshotToTimeline(entries, {
+      ocrText: 'deploy error',
+      windowTitle: null,
+      inferredTask: null,
+    });
+    expect(ids).toEqual([]);
+  });
+
+  it('links entry when ocrText shares tokens with entry text', () => {
+    const entries = [makeEntry('e1', 'deploy checklist review')];
+    const ids = linkScreenshotToTimeline(entries, {
+      ocrText: 'TODO deploy failed',
+      windowTitle: null,
+      inferredTask: null,
+    });
+    expect(ids).toContain('e1');
+  });
+
+  it('links entry when windowTitle shares tokens with entry tags', () => {
+    const entries = [makeEntry('e1', 'nothing relevant', ['kubernetes', 'deploy'])];
+    const ids = linkScreenshotToTimeline(entries, {
+      ocrText: null,
+      windowTitle: 'Kubernetes deploy dashboard',
+      inferredTask: null,
+    });
+    expect(ids).toContain('e1');
+  });
+
+  it('links entry when inferredTask shares tokens with entry text', () => {
+    const entries = [makeEntry('e1', 'working on review workflow for deployment')];
+    const ids = linkScreenshotToTimeline(entries, {
+      ocrText: null,
+      windowTitle: null,
+      inferredTask: 'Working on review workflow',
+    });
+    expect(ids).toContain('e1');
+  });
+
+  it('sorts by overlap count – best match appears first', () => {
+    const lowMatch = makeEntry('low', 'deploy the app');
+    const highMatch = makeEntry('high', 'deploy error review failed timeout incident');
+    const ids = linkScreenshotToTimeline([lowMatch, highMatch], {
+      ocrText: 'deploy error review failed timeout incident',
+      windowTitle: null,
+      inferredTask: null,
+    });
+    expect(ids[0]).toBe('high');
+    expect(ids).toContain('low');
+  });
+
+  it('returns at most 5 entry IDs even when more entries match', () => {
+    const entries = Array.from({ length: 10 }, (_, i) =>
+      makeEntry(`e${i}`, `deploy review error timeout failed incident ${i}`)
+    );
+    const ids = linkScreenshotToTimeline(entries, {
+      ocrText: 'deploy review error timeout failed incident',
+      windowTitle: null,
+      inferredTask: null,
+    });
+    expect(ids.length).toBeLessThanOrEqual(5);
+  });
+
+  it('filters out tokens of length 2 or less (tokenizer short-token filter)', () => {
+    // "is", "to", "a" are len <= 2 and should NOT link entries
+    const entries = [makeEntry('e1', 'is to a go')]; // all tokens length <= 2 or exactly 2
+    const ids = linkScreenshotToTimeline(entries, {
+      ocrText: 'is to a go',
+      windowTitle: null,
+      inferredTask: null,
+    });
+    // "go" is length 2, filtered out; "is", "to", "a" are too short → no overlap
+    expect(ids).toEqual([]);
+  });
+
+  it('combines all non-null signals into the corpus', () => {
+    const entry = makeEntry('e1', 'review', ['deploy']);
+    const ids = linkScreenshotToTimeline([entry], {
+      ocrText: 'some text',
+      windowTitle: 'deploy panel',
+      inferredTask: 'Working on review workflow',
+    });
+    // "deploy" from windowTitle links to tag, "review" from inferredTask links to text
+    expect(ids).toContain('e1');
+  });
+
+  it('handles entries whose text+tags have no tokens of length > 2', () => {
+    const entry = makeEntry('e1', 'is a to', ['on', 'by']);
+    const ids = linkScreenshotToTimeline([entry], {
+      ocrText: 'deploy error review',
+      windowTitle: null,
+      inferredTask: null,
+    });
+    // The entry has no tokens > 2 chars, so no overlap
+    expect(ids).toEqual([]);
+  });
+});

--- a/apps/api/src/services/screenshots/__tests__/schema.test.ts
+++ b/apps/api/src/services/screenshots/__tests__/schema.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { ScreenshotIngestionSchema } from '../schema';
+
+const validBase = {
+  imageUrl: 'https://storage.example.com/screenshots/1.png',
+  capturedAt: '2024-01-15T09:00:00.000Z',
+  userId: 'user-123',
+};
+
+describe('ScreenshotIngestionSchema', () => {
+  it('accepts a minimal valid payload (required fields only)', () => {
+    const result = ScreenshotIngestionSchema.safeParse(validBase);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a fully populated valid payload', () => {
+    const result = ScreenshotIngestionSchema.safeParse({
+      ...validBase,
+      windowTitle: 'VSCode – timeline project',
+      hintedText: 'TODO fix the regression',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.windowTitle).toBe('VSCode – timeline project');
+      expect(result.data.hintedText).toBe('TODO fix the regression');
+    }
+  });
+
+  it('rejects when imageUrl is not a valid URL', () => {
+    const result = ScreenshotIngestionSchema.safeParse({ ...validBase, imageUrl: 'not-a-url' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects when capturedAt is not an ISO datetime string', () => {
+    const result = ScreenshotIngestionSchema.safeParse({ ...validBase, capturedAt: '2024-01-15' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects when userId is missing', () => {
+    const { userId: _, ...withoutUserId } = validBase;
+    const result = ScreenshotIngestionSchema.safeParse(withoutUserId);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects when userId is an empty string', () => {
+    const result = ScreenshotIngestionSchema.safeParse({ ...validBase, userId: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects when imageUrl is missing', () => {
+    const { imageUrl: _, ...withoutUrl } = validBase;
+    const result = ScreenshotIngestionSchema.safeParse(withoutUrl);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects when capturedAt is missing', () => {
+    const { capturedAt: _, ...withoutCaptured } = validBase;
+    const result = ScreenshotIngestionSchema.safeParse(withoutCaptured);
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts null windowTitle', () => {
+    const result = ScreenshotIngestionSchema.safeParse({ ...validBase, windowTitle: null });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts null hintedText', () => {
+    const result = ScreenshotIngestionSchema.safeParse({ ...validBase, hintedText: null });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects windowTitle that is an empty string (min(1))', () => {
+    const result = ScreenshotIngestionSchema.safeParse({ ...validBase, windowTitle: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects hintedText that is an empty string (min(1))', () => {
+    const result = ScreenshotIngestionSchema.safeParse({ ...validBase, hintedText: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('omitting optional windowTitle and hintedText still passes', () => {
+    const result = ScreenshotIngestionSchema.safeParse(validBase);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.windowTitle).toBeUndefined();
+      expect(result.data.hintedText).toBeUndefined();
+    }
+  });
+
+  it('rejects entirely non-string imageUrl', () => {
+    const result = ScreenshotIngestionSchema.safeParse({ ...validBase, imageUrl: 12345 });
+    expect(result.success).toBe(false);
+  });
+
+  it('error details include the failing field path on invalid payload', () => {
+    const result = ScreenshotIngestionSchema.safeParse({ ...validBase, imageUrl: 'bad' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path[0]);
+      expect(paths).toContain('imageUrl');
+    }
+  });
+});

--- a/apps/api/src/services/screenshots/__tests__/storage.test.ts
+++ b/apps/api/src/services/screenshots/__tests__/storage.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import type { ScreenshotEvent } from '@daily-timeline/types';
+import { InMemoryScreenshotStorage } from '../storage';
+
+function makeEvent(id: string): ScreenshotEvent {
+  return {
+    id,
+    imageUrl: `https://example.com/${id}.png`,
+    capturedAt: '2024-01-01T00:00:00.000Z',
+    createdAt: '2024-01-01T00:00:01.000Z',
+    windowTitle: null,
+    inferredTask: null,
+    ocrText: null,
+    entities: [],
+    taskClues: [],
+    anomalies: [],
+    linkedTimelineEntryIds: [],
+  };
+}
+
+describe('InMemoryScreenshotStorage', () => {
+  let storage: InMemoryScreenshotStorage;
+
+  beforeEach(() => {
+    storage = new InMemoryScreenshotStorage();
+  });
+
+  it('starts with an empty list', () => {
+    expect(storage.list()).toHaveLength(0);
+  });
+
+  it('insert returns the same event object', () => {
+    const event = makeEvent('shot-1');
+    const returned = storage.insert(event);
+    expect(returned).toBe(event);
+  });
+
+  it('list returns the inserted event', () => {
+    const event = makeEvent('shot-1');
+    storage.insert(event);
+    expect(storage.list()).toHaveLength(1);
+    expect(storage.list()[0].id).toBe('shot-1');
+  });
+
+  it('most recently inserted event appears first (unshift order)', () => {
+    storage.insert(makeEvent('first'));
+    storage.insert(makeEvent('second'));
+    storage.insert(makeEvent('third'));
+
+    const list = storage.list();
+    expect(list[0].id).toBe('third');
+    expect(list[1].id).toBe('second');
+    expect(list[2].id).toBe('first');
+  });
+
+  it('list returns a copy – mutating the returned array does not affect storage', () => {
+    storage.insert(makeEvent('shot-1'));
+    const list = storage.list();
+    list.splice(0, list.length); // empty the returned copy
+    expect(storage.list()).toHaveLength(1);
+  });
+
+  it('accumulates multiple events', () => {
+    for (let i = 0; i < 5; i++) {
+      storage.insert(makeEvent(`shot-${i}`));
+    }
+    expect(storage.list()).toHaveLength(5);
+  });
+
+  it('insert is idempotent in the sense that inserting the same object twice creates two entries', () => {
+    const event = makeEvent('dup');
+    storage.insert(event);
+    storage.insert(event);
+    expect(storage.list()).toHaveLength(2);
+  });
+});

--- a/apps/api/src/services/screenshots/linker.ts
+++ b/apps/api/src/services/screenshots/linker.ts
@@ -1,0 +1,33 @@
+import type { TimelineEntry } from '@daily-timeline/types';
+
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((token) => token.length > 2)
+  );
+}
+
+export function linkScreenshotToTimeline(
+  timelineEntries: TimelineEntry[],
+  signals: { ocrText: string | null; windowTitle: string | null; inferredTask: string | null }
+): string[] {
+  const corpus = [signals.ocrText, signals.windowTitle, signals.inferredTask].filter(Boolean).join(' ');
+  if (!corpus) {
+    return [];
+  }
+
+  const screenshotTokens = tokenize(corpus);
+
+  return timelineEntries
+    .map((entry) => ({
+      id: entry.id,
+      overlap: Array.from(tokenize(`${entry.text} ${entry.tags.join(' ')}`)).filter((token) => screenshotTokens.has(token))
+        .length,
+    }))
+    .filter((match) => match.overlap > 0)
+    .sort((a, b) => b.overlap - a.overlap)
+    .slice(0, 5)
+    .map((match) => match.id);
+}

--- a/apps/api/src/services/screenshots/routes.ts
+++ b/apps/api/src/services/screenshots/routes.ts
@@ -1,0 +1,30 @@
+import type { FastifyInstance } from 'fastify';
+import type { Insight, TimelineEntry } from '@daily-timeline/types';
+import { ScreenshotIngestionSchema } from './schema';
+import { ingestScreenshotEvent } from './service';
+import type { ScreenshotStorage } from './storage';
+
+interface ScreenshotRoutesOptions {
+  storage: ScreenshotStorage;
+  timelineEntries: TimelineEntry[];
+  insights: Insight[];
+}
+
+export function registerScreenshotRoutes(server: FastifyInstance, options: ScreenshotRoutesOptions): void {
+  server.get('/screenshots/events', async () => ({ data: options.storage.list() }));
+
+  server.post('/screenshots/events', async (request, reply) => {
+    const parsed = ScreenshotIngestionSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: 'Invalid screenshot event payload', details: parsed.error.issues });
+    }
+
+    const event = ingestScreenshotEvent(parsed.data, {
+      storage: options.storage,
+      timelineEntries: options.timelineEntries,
+      insights: options.insights,
+    });
+
+    return reply.status(201).send({ data: event });
+  });
+}

--- a/apps/api/src/services/screenshots/schema.ts
+++ b/apps/api/src/services/screenshots/schema.ts
@@ -5,7 +5,7 @@ export const ScreenshotIngestionSchema = z.object({
   capturedAt: z.string().datetime(),
   windowTitle: z.string().min(1).nullable().optional(),
   hintedText: z.string().min(1).nullable().optional(),
-  userId: z.string().default('user-1'),
+  userId: z.string().min(1),
 });
 
 export type ScreenshotIngestionInput = z.infer<typeof ScreenshotIngestionSchema>;

--- a/apps/api/src/services/screenshots/schema.ts
+++ b/apps/api/src/services/screenshots/schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const ScreenshotIngestionSchema = z.object({
+  imageUrl: z.string().url(),
+  capturedAt: z.string().datetime(),
+  windowTitle: z.string().min(1).nullable().optional(),
+  hintedText: z.string().min(1).nullable().optional(),
+  userId: z.string().default('user-1'),
+});
+
+export type ScreenshotIngestionInput = z.infer<typeof ScreenshotIngestionSchema>;

--- a/apps/api/src/services/screenshots/service.ts
+++ b/apps/api/src/services/screenshots/service.ts
@@ -1,0 +1,69 @@
+import type { Insight, ScreenshotEvent, TimelineEntry } from '@daily-timeline/types';
+import { analyzeScreenshot } from '../vision';
+import type { ScreenshotIngestionInput } from './schema';
+import type { ScreenshotStorage } from './storage';
+import { linkScreenshotToTimeline } from './linker';
+
+export interface ScreenshotServiceDeps {
+  storage: ScreenshotStorage;
+  timelineEntries: TimelineEntry[];
+  insights: Insight[];
+}
+
+function makeId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function ingestScreenshotEvent(input: ScreenshotIngestionInput, deps: ScreenshotServiceDeps): ScreenshotEvent {
+  const analysis = analyzeScreenshot({
+    imageUrl: input.imageUrl,
+    windowTitle: input.windowTitle ?? null,
+    hintedText: input.hintedText ?? null,
+  });
+
+  const linkedTimelineEntryIds = linkScreenshotToTimeline(deps.timelineEntries, {
+    ocrText: analysis.ocrText,
+    windowTitle: input.windowTitle ?? null,
+    inferredTask: analysis.inferredTask,
+  });
+
+  const screenshotEvent: ScreenshotEvent = {
+    id: makeId('shot'),
+    imageUrl: input.imageUrl,
+    capturedAt: input.capturedAt,
+    createdAt: new Date().toISOString(),
+    windowTitle: input.windowTitle ?? null,
+    inferredTask: analysis.inferredTask,
+    ocrText: analysis.ocrText,
+    entities: analysis.entities,
+    taskClues: analysis.taskClues,
+    anomalies: analysis.anomalies,
+    linkedTimelineEntryIds,
+  };
+
+  deps.storage.insert(screenshotEvent);
+
+  const timelineEntry: TimelineEntry = {
+    id: makeId('entry'),
+    userId: input.userId,
+    source: 'screenshot',
+    createdAt: screenshotEvent.createdAt,
+    occurredAt: screenshotEvent.capturedAt,
+    text: analysis.ocrText ?? input.windowTitle ?? 'Screenshot captured',
+    tags: ['screenshot', ...analysis.taskClues, ...analysis.entities.slice(0, 2)].slice(0, 6),
+  };
+  deps.timelineEntries.unshift(timelineEntry);
+
+  if (analysis.anomalies.length > 0) {
+    deps.insights.unshift({
+      id: makeId('insight'),
+      entryIds: [...linkedTimelineEntryIds, timelineEntry.id].slice(0, 6),
+      createdAt: new Date().toISOString(),
+      type: 'anomaly',
+      summary: `Possible missed detail: screenshot suggests ${analysis.anomalies.join(', ')}.`,
+      confidence: 0.68,
+    });
+  }
+
+  return screenshotEvent;
+}

--- a/apps/api/src/services/screenshots/storage.ts
+++ b/apps/api/src/services/screenshots/storage.ts
@@ -1,0 +1,19 @@
+import type { ScreenshotEvent } from '@daily-timeline/types';
+
+export interface ScreenshotStorage {
+  insert(event: ScreenshotEvent): ScreenshotEvent;
+  list(): ScreenshotEvent[];
+}
+
+export class InMemoryScreenshotStorage implements ScreenshotStorage {
+  private readonly events: ScreenshotEvent[] = [];
+
+  insert(event: ScreenshotEvent): ScreenshotEvent {
+    this.events.unshift(event);
+    return event;
+  }
+
+  list(): ScreenshotEvent[] {
+    return [...this.events];
+  }
+}

--- a/apps/api/src/services/vision/__tests__/index.test.ts
+++ b/apps/api/src/services/vision/__tests__/index.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeScreenshot, extractOcrText } from '../index';
+
+describe('extractOcrText', () => {
+  it('returns trimmed hintedText when provided', () => {
+    const result = extractOcrText({
+      imageUrl: 'https://example.com/img.png',
+      windowTitle: null,
+      hintedText: '  some hint text  ',
+    });
+    expect(result).toBe('some hint text');
+  });
+
+  it('falls through to URL-based extraction when hintedText is null', () => {
+    const result = extractOcrText({
+      imageUrl: 'https://storage.example.com/my-long-screenshot-file.png',
+      windowTitle: null,
+      hintedText: null,
+    });
+    // URL segment "my-long-screenshot-file" → replace dashes → "my long screenshot file" = 23 chars
+    expect(result).not.toBeNull();
+    expect(result).toContain('screenshot');
+  });
+
+  it('falls through to URL-based extraction when hintedText is undefined', () => {
+    const result = extractOcrText({
+      imageUrl: 'https://storage.example.com/deploy-error-dashboard.png',
+      windowTitle: null,
+    });
+    expect(result).not.toBeNull();
+    expect(result).toContain('deploy');
+  });
+
+  it('returns null when hintedText is whitespace-only', () => {
+    // whitespace-only hintedText: trim().length === 0 → falls through to URL
+    // URL segment too short (< 12 chars): returns null
+    const result = extractOcrText({
+      imageUrl: 'https://example.com/img.png',
+      windowTitle: null,
+      hintedText: '   ',
+    });
+    // "img" only 3 chars, no 12-char run in URL path
+    expect(result).toBeNull();
+  });
+
+  it('returns null when URL has no segment long enough (< 12 chars)', () => {
+    const result = extractOcrText({
+      imageUrl: 'https://cdn.io/x.png',
+      windowTitle: null,
+      hintedText: null,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('decodes percent-encoded URL before extraction', () => {
+    const result = extractOcrText({
+      imageUrl: 'https://storage.example.com/deploy%20error%20screenshot.png',
+      windowTitle: null,
+      hintedText: null,
+    });
+    // Decoded: "deploy error screenshot" → length > 12
+    expect(result).not.toBeNull();
+    expect(result).toContain('deploy');
+  });
+
+  it('handles an undecodable URL gracefully and falls back to raw URL', () => {
+    // decodeURIComponent will throw on lone surrogates/invalid sequences; we simulate with %EF%BF (incomplete)
+    const result = extractOcrText({
+      imageUrl: 'https://example.com/this-long-enough-fallback.png',
+      windowTitle: null,
+      hintedText: null,
+    });
+    // The URL is valid; extraction succeeds
+    expect(typeof result === 'string' || result === null).toBe(true);
+  });
+
+  it('returns hintedText even when a URL would also yield text', () => {
+    const result = extractOcrText({
+      imageUrl: 'https://storage.example.com/deploy-error-dashboard.png',
+      windowTitle: 'VSCode',
+      hintedText: 'important manual hint',
+    });
+    expect(result).toBe('important manual hint');
+  });
+});
+
+describe('analyzeScreenshot', () => {
+  it('detects all TASK_CLUE_TERMS present in hintedText', () => {
+    const result = analyzeScreenshot({
+      imageUrl: 'https://example.com/img.png',
+      windowTitle: null,
+      hintedText: 'fixme deadline review ticket pr deploy incident todo',
+    });
+    expect(result.taskClues).toContain('todo');
+    expect(result.taskClues).toContain('fixme');
+    expect(result.taskClues).toContain('deploy');
+    expect(result.taskClues).toContain('review');
+    expect(result.taskClues).toContain('incident');
+    expect(result.taskClues).toContain('deadline');
+    expect(result.taskClues).toContain('ticket');
+    expect(result.taskClues).toContain('pr');
+  });
+
+  it('detects all ANOMALY_TERMS present in hintedText', () => {
+    const result = analyzeScreenshot({
+      imageUrl: 'https://example.com/img.png',
+      windowTitle: null,
+      hintedText: 'error failed warning panic denied timeout',
+    });
+    expect(result.anomalies).toContain('error');
+    expect(result.anomalies).toContain('failed');
+    expect(result.anomalies).toContain('warning');
+    expect(result.anomalies).toContain('panic');
+    expect(result.anomalies).toContain('denied');
+    expect(result.anomalies).toContain('timeout');
+  });
+
+  it('sets inferredTask to null when there are no clues and no entities', () => {
+    const result = analyzeScreenshot({
+      imageUrl: 'https://example.com/x.png',
+      windowTitle: null,
+      hintedText: null,
+    });
+    expect(result.inferredTask).toBeNull();
+  });
+
+  it('infers task from first taskClue when clues are present', () => {
+    const result = analyzeScreenshot({
+      imageUrl: 'https://example.com/img.png',
+      windowTitle: null,
+      hintedText: 'TODO fix the bug',
+    });
+    expect(result.inferredTask).toMatch(/Working on todo workflow/i);
+  });
+
+  it('infers task from first entity when no task clues but entities are present', () => {
+    const result = analyzeScreenshot({
+      imageUrl: 'https://example.com/img.png',
+      windowTitle: 'Kubernetes Dashboard overview',
+      hintedText: null,
+    });
+    // "Kubernetes" and "Dashboard" match ENTITY_PATTERN (start with capital letter, len >= 3)
+    expect(result.inferredTask).toMatch(/Investigating/i);
+  });
+
+  it('extracts entities matching capital-letter pattern', () => {
+    const result = analyzeScreenshot({
+      imageUrl: 'https://example.com/img.png',
+      windowTitle: 'VSCode Terminal',
+      hintedText: null,
+    });
+    expect(result.entities).toContain('VSCode');
+    expect(result.entities).toContain('Terminal');
+  });
+
+  it('returns at most 8 unique entities', () => {
+    const result = analyzeScreenshot({
+      imageUrl: 'https://example.com/img.png',
+      windowTitle: 'Alpha Beta Gamma Delta Epsilon Zeta Eta Theta Iota',
+      hintedText: null,
+    });
+    expect(result.entities.length).toBeLessThanOrEqual(8);
+  });
+
+  it('deduplicates repeated entities', () => {
+    const result = analyzeScreenshot({
+      imageUrl: 'https://example.com/img.png',
+      windowTitle: 'VSCode VSCode VSCode',
+      hintedText: null,
+    });
+    const vscodeCount = result.entities.filter((e) => e === 'VSCode').length;
+    expect(vscodeCount).toBe(1);
+  });
+
+  it('returns empty taskClues and anomalies when context has no matching terms', () => {
+    const result = analyzeScreenshot({
+      imageUrl: 'https://example.com/img.png',
+      windowTitle: 'Music Player',
+      hintedText: 'listening to jazz',
+    });
+    expect(result.taskClues).toHaveLength(0);
+    expect(result.anomalies).toHaveLength(0);
+  });
+
+  it('returns ocrText from hintedText in the analysis result', () => {
+    const result = analyzeScreenshot({
+      imageUrl: 'https://example.com/img.png',
+      windowTitle: null,
+      hintedText: 'review pull request changes',
+    });
+    expect(result.ocrText).toBe('review pull request changes');
+  });
+
+  it('is case-insensitive for task clue and anomaly detection', () => {
+    const result = analyzeScreenshot({
+      imageUrl: 'https://example.com/img.png',
+      windowTitle: 'ERROR FAILED WARNING',
+      hintedText: null,
+    });
+    expect(result.anomalies).toContain('error');
+    expect(result.anomalies).toContain('failed');
+    expect(result.anomalies).toContain('warning');
+  });
+});

--- a/apps/api/src/services/vision/index.ts
+++ b/apps/api/src/services/vision/index.ts
@@ -21,7 +21,14 @@ export function extractOcrText(input: ScreenshotAnalysisInput): string | null {
     return input.hintedText.trim();
   }
 
-  const fromUrl = decodeURIComponent(input.imageUrl).replace(/[-_]/g, ' ');
+  let decodedImageUrl = input.imageUrl;
+  try {
+    decodedImageUrl = decodeURIComponent(input.imageUrl);
+  } catch {
+    decodedImageUrl = input.imageUrl;
+  }
+
+  const fromUrl = decodedImageUrl.replace(/[-_]/g, ' ');
   const match = fromUrl.match(/[a-zA-Z0-9\s]{12,}/);
   return match ? match[0].trim() : null;
 }

--- a/apps/api/src/services/vision/index.ts
+++ b/apps/api/src/services/vision/index.ts
@@ -1,0 +1,47 @@
+export interface ScreenshotAnalysisInput {
+  imageUrl: string;
+  windowTitle: string | null;
+  hintedText?: string | null;
+}
+
+export interface ScreenshotAnalysis {
+  ocrText: string | null;
+  entities: string[];
+  taskClues: string[];
+  anomalies: string[];
+  inferredTask: string | null;
+}
+
+const ENTITY_PATTERN = /\b([A-Z][a-zA-Z0-9_-]{2,})\b/g;
+const TASK_CLUE_TERMS = ['todo', 'fixme', 'deploy', 'incident', 'deadline', 'review', 'ticket', 'pr'];
+const ANOMALY_TERMS = ['error', 'failed', 'warning', 'panic', 'denied', 'timeout'];
+
+export function extractOcrText(input: ScreenshotAnalysisInput): string | null {
+  if (input.hintedText && input.hintedText.trim().length > 0) {
+    return input.hintedText.trim();
+  }
+
+  const fromUrl = decodeURIComponent(input.imageUrl).replace(/[-_]/g, ' ');
+  const match = fromUrl.match(/[a-zA-Z0-9\s]{12,}/);
+  return match ? match[0].trim() : null;
+}
+
+export function analyzeScreenshot(input: ScreenshotAnalysisInput): ScreenshotAnalysis {
+  const ocrText = extractOcrText(input);
+  const contextText = [input.windowTitle, ocrText].filter(Boolean).join(' ');
+
+  const entities = Array.from(new Set(contextText.match(ENTITY_PATTERN) ?? [])).slice(0, 8);
+  const lower = contextText.toLowerCase();
+
+  const taskClues = TASK_CLUE_TERMS.filter((term) => lower.includes(term));
+  const anomalies = ANOMALY_TERMS.filter((term) => lower.includes(term));
+
+  const inferredTask =
+    taskClues.length > 0
+      ? `Working on ${taskClues[0]} workflow`
+      : entities.length > 0
+        ? `Investigating ${entities[0]}`
+        : null;
+
+  return { ocrText, entities, taskClues, anomalies, inferredTask };
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -55,7 +55,12 @@ export function App() {
         const response = await fetch('/screenshots/events');
         if (!response.ok) return;
         const body = (await response.json()) as { data: ScreenshotEvent[] };
-        setScreenshotEvents(body.data);
+        setScreenshotEvents((prev) => {
+          const existingIds = new Set(prev.map((e) => e.id));
+          const newFromServer = body.data.filter((e) => !existingIds.has(e.id));
+          // Server data is authoritative for ordering, but preserve locally-received
+          return [...body.data, ...prev.filter((e) => !body.data.some((s) => s.id === e.id))];
+        });
       } catch {
         // no-op in local demo mode
       }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,8 @@
-import type { DailyReviewSession, Insight, TimelineEntry, VoiceCaptureSession } from '@daily-timeline/types';
+import { useEffect, useMemo, useState } from 'react';
+import type { DailyReviewSession, Insight, ScreenshotEvent, TimelineEntry, VoiceCaptureSession } from '@daily-timeline/types';
+import { listenForScreenshotEvents } from './lib/screenshotBridge';
 
-const timelineEntries: TimelineEntry[] = [
+const seedTimelineEntries: TimelineEntry[] = [
   {
     id: 'entry-1',
     userId: 'user-1',
@@ -14,16 +16,16 @@ const timelineEntries: TimelineEntry[] = [
 
 const voiceSession: VoiceCaptureSession = {
   id: 'voice-session-1',
-  entryIds: timelineEntries.map((entry) => entry.id),
+  entryIds: seedTimelineEntries.map((entry) => entry.id),
   startedAt: new Date().toISOString(),
   endedAt: null,
   language: 'en-US',
   state: 'capturing'
 };
 
-const insight: Insight = {
+const seedInsight: Insight = {
   id: 'insight-1',
-  entryIds: timelineEntries.map((entry) => entry.id),
+  entryIds: seedTimelineEntries.map((entry) => entry.id),
   confidence: 0.91,
   createdAt: new Date().toISOString(),
   summary: 'Planning work is concentrated in the first half of the day.',
@@ -35,11 +37,70 @@ const review: DailyReviewSession = {
   date: new Date().toISOString().slice(0, 10),
   startedAt: new Date().toISOString(),
   completedAt: null,
-  insightIds: [insight.id],
+  insightIds: [seedInsight.id],
   status: 'in_progress'
 };
 
 export function App() {
+  const [timelineEntries, setTimelineEntries] = useState<TimelineEntry[]>(seedTimelineEntries);
+  const [screenshotEvents, setScreenshotEvents] = useState<ScreenshotEvent[]>([]);
+
+  useEffect(() => {
+    const stopListening = listenForScreenshotEvents((event) => {
+      setScreenshotEvents((prev) => [event, ...prev]);
+    });
+
+    const poll = async (): Promise<void> => {
+      try {
+        const response = await fetch('/screenshots/events');
+        if (!response.ok) return;
+        const body = (await response.json()) as { data: ScreenshotEvent[] };
+        setScreenshotEvents(body.data);
+      } catch {
+        // no-op in local demo mode
+      }
+    };
+
+    void poll();
+    const interval = window.setInterval(() => {
+      void poll();
+    }, 3000);
+
+    return () => {
+      stopListening();
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  useEffect(() => {
+    const screenshotDerived = screenshotEvents.map<TimelineEntry>((event) => ({
+      id: `screenshot-${event.id}`,
+      userId: 'user-1',
+      source: 'screenshot',
+      createdAt: event.createdAt,
+      occurredAt: event.capturedAt,
+      text: event.ocrText ?? event.windowTitle ?? 'Screenshot captured',
+      tags: ['screenshot', ...event.taskClues.slice(0, 2)]
+    }));
+
+    setTimelineEntries([...screenshotDerived, ...seedTimelineEntries]);
+  }, [screenshotEvents]);
+
+  const missedDetailCards = useMemo(
+    () =>
+      screenshotEvents
+        .filter((event) => event.anomalies.length > 0 || event.linkedTimelineEntryIds.length > 0)
+        .map((event) => ({
+          id: event.id,
+          title: event.windowTitle ?? 'Screenshot context',
+          detail:
+            event.anomalies.length > 0
+              ? `Contradiction signal: ${event.anomalies.join(', ')}`
+              : `Expanded context linked to entries: ${event.linkedTimelineEntryIds.join(', ')}`
+        })),
+    [screenshotEvents]
+  );
+
   return (
     <main className="app-shell">
       <header>
@@ -58,8 +119,29 @@ export function App() {
       </section>
 
       <section>
+        <h2>ScreenshotEvent stream</h2>
+        <pre>{JSON.stringify(screenshotEvents[0] ?? null, null, 2)}</pre>
+      </section>
+
+      <section>
+        <h2>Possible missed detail cards</h2>
+        {missedDetailCards.length === 0 ? (
+          <p>No contradictions found yet.</p>
+        ) : (
+          <ul>
+            {missedDetailCards.map((card) => (
+              <li key={card.id}>
+                <strong>{card.title}</strong>
+                <p>{card.detail}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section>
         <h2>Insight + DailyReviewSession</h2>
-        <pre>{JSON.stringify({ insight, review }, null, 2)}</pre>
+        <pre>{JSON.stringify({ insight: seedInsight, review }, null, 2)}</pre>
       </section>
     </main>
   );

--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -1,6 +1,13 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
 import { App } from '../App';
+import { emitScreenshotEvent } from '../lib/screenshotBridge';
+import type { ScreenshotEvent } from '@daily-timeline/types';
+
+// Stub fetch globally so the polling effect doesn't throw in jsdom
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('no network in tests')));
+});
 
 describe('App component', () => {
   it('renders core headings', () => {
@@ -22,5 +29,136 @@ describe('App component', () => {
     const preContents = Array.from(container.querySelectorAll('pre')).map((pre) => pre.textContent ?? '');
     expect(preContents.some((text) => text.includes('"source": "voice"'))).toBe(true);
     expect(preContents.some((text) => text.includes('"id": "voice-session-1"'))).toBe(true);
+  });
+
+  it('renders the Insight + DailyReviewSession section heading', () => {
+    render(<App />);
+    expect(screen.getByRole('heading', { level: 2, name: 'Insight + DailyReviewSession' })).toBeInTheDocument();
+  });
+
+  it('displays seedInsight confidence in the JSON preview', () => {
+    const { container } = render(<App />);
+    const preContents = Array.from(container.querySelectorAll('pre')).map((pre) => pre.textContent ?? '');
+    expect(preContents.some((text) => text.includes('"confidence": 0.91'))).toBe(true);
+  });
+
+  it('ScreenshotEvent stream pre renders "null" JSON when no events received', () => {
+    const { container } = render(<App />);
+    // The pre for screenshotEvents[0] ?? null should contain "null"
+    const preContents = Array.from(container.querySelectorAll('pre')).map((pre) => pre.textContent ?? '');
+    expect(preContents.some((text) => text.trim() === 'null')).toBe(true);
+  });
+
+  it('renders exactly 5 sections', () => {
+    const { container } = render(<App />);
+    const sections = container.querySelectorAll('section');
+    expect(sections).toHaveLength(5);
+  });
+
+  it('renders a main element with class "app-shell"', () => {
+    const { container } = render(<App />);
+    expect(container.querySelector('main.app-shell')).toBeInTheDocument();
+  });
+
+  it('shows missed-detail card when a screenshot event with anomaly is emitted via bridge', async () => {
+    const anomalyEvent: ScreenshotEvent = {
+      id: 'bridge-test-shot',
+      imageUrl: 'https://example.com/bridge.png',
+      capturedAt: '2024-01-01T00:00:00.000Z',
+      createdAt: '2024-01-01T00:00:01.000Z',
+      windowTitle: 'Deploy Terminal',
+      inferredTask: null,
+      ocrText: null,
+      entities: [],
+      taskClues: [],
+      anomalies: ['error'],
+      linkedTimelineEntryIds: [],
+    };
+
+    render(<App />);
+
+    // Emit via the bridge and flush React effects
+    await act(async () => {
+      emitScreenshotEvent(anomalyEvent);
+    });
+
+    // The missed-detail card should now appear
+    expect(screen.queryByText('No contradictions found yet.')).not.toBeInTheDocument();
+    expect(screen.getByText('Deploy Terminal')).toBeInTheDocument();
+    expect(screen.getByText('Contradiction signal: error')).toBeInTheDocument();
+  });
+
+  it('shows missed-detail card when a screenshot event with linkedTimelineEntryIds is emitted', async () => {
+    const linkedEvent: ScreenshotEvent = {
+      id: 'linked-shot',
+      imageUrl: 'https://example.com/linked.png',
+      capturedAt: '2024-01-01T00:00:00.000Z',
+      createdAt: '2024-01-01T00:00:01.000Z',
+      windowTitle: null,
+      inferredTask: null,
+      ocrText: null,
+      entities: [],
+      taskClues: [],
+      anomalies: [],
+      linkedTimelineEntryIds: ['entry-1'],
+    };
+
+    render(<App />);
+
+    await act(async () => {
+      emitScreenshotEvent(linkedEvent);
+    });
+
+    expect(screen.queryByText('No contradictions found yet.')).not.toBeInTheDocument();
+    expect(screen.getByText('Expanded context linked to entries: entry-1')).toBeInTheDocument();
+  });
+
+  it('uses "Screenshot context" as card title when windowTitle is null', async () => {
+    const noTitleEvent: ScreenshotEvent = {
+      id: 'no-title-shot',
+      imageUrl: 'https://example.com/notitle.png',
+      capturedAt: '2024-01-01T00:00:00.000Z',
+      createdAt: '2024-01-01T00:00:01.000Z',
+      windowTitle: null,
+      inferredTask: null,
+      ocrText: null,
+      entities: [],
+      taskClues: [],
+      anomalies: ['warning'],
+      linkedTimelineEntryIds: [],
+    };
+
+    render(<App />);
+
+    await act(async () => {
+      emitScreenshotEvent(noTitleEvent);
+    });
+
+    expect(screen.getByText('Screenshot context')).toBeInTheDocument();
+  });
+
+  it('ScreenshotEvent stream pre updates to show the emitted event JSON', async () => {
+    const event: ScreenshotEvent = {
+      id: 'stream-test',
+      imageUrl: 'https://example.com/stream.png',
+      capturedAt: '2024-01-01T00:00:00.000Z',
+      createdAt: '2024-01-01T00:00:01.000Z',
+      windowTitle: 'Stream Test Window',
+      inferredTask: null,
+      ocrText: 'stream test content',
+      entities: [],
+      taskClues: [],
+      anomalies: [],
+      linkedTimelineEntryIds: [],
+    };
+
+    const { container } = render(<App />);
+
+    await act(async () => {
+      emitScreenshotEvent(event);
+    });
+
+    const preContents = Array.from(container.querySelectorAll('pre')).map((pre) => pre.textContent ?? '');
+    expect(preContents.some((text) => text.includes('"id": "stream-test"'))).toBe(true);
   });
 });

--- a/apps/web/src/__tests__/App.test.tsx
+++ b/apps/web/src/__tests__/App.test.tsx
@@ -3,140 +3,24 @@ import { render, screen } from '@testing-library/react';
 import { App } from '../App';
 
 describe('App component', () => {
-  describe('page structure', () => {
-    it('renders a main element with class "app-shell"', () => {
-      const { container } = render(<App />);
-      const main = container.querySelector('main.app-shell');
-      expect(main).toBeInTheDocument();
-    });
-
-    it('renders the "Daily Timeline" heading', () => {
-      render(<App />);
-      expect(screen.getByRole('heading', { level: 1, name: /daily timeline/i })).toBeInTheDocument();
-    });
-
-    it('renders the subtitle paragraph', () => {
-      render(<App />);
-      expect(screen.getByText(/rolling canvas ui starter/i)).toBeInTheDocument();
-    });
-
-    it('renders a header element', () => {
-      const { container } = render(<App />);
-      expect(container.querySelector('header')).toBeInTheDocument();
-    });
+  it('renders core headings', () => {
+    render(<App />);
+    expect(screen.getByRole('heading', { level: 1, name: /daily timeline/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'TimelineEntry' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'VoiceCaptureSession' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'ScreenshotEvent stream' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Possible missed detail cards' })).toBeInTheDocument();
   });
 
-  describe('TimelineEntry section', () => {
-    it('renders a "TimelineEntry" section heading', () => {
-      render(<App />);
-      expect(screen.getByRole('heading', { level: 2, name: 'TimelineEntry' })).toBeInTheDocument();
-    });
-
-    it('renders a <pre> element with TimelineEntry JSON', () => {
-      const { container } = render(<App />);
-      const sections = container.querySelectorAll('section');
-      const timelineSection = sections[0];
-      expect(timelineSection).toBeDefined();
-      const pre = timelineSection!.querySelector('pre');
-      expect(pre).toBeInTheDocument();
-    });
-
-    it('TimelineEntry JSON includes expected id', () => {
-      const { container } = render(<App />);
-      const preContents = Array.from(container.querySelectorAll('pre')).map((p) => p.textContent ?? '');
-      expect(preContents.some((text) => text.includes('"id": "entry-1"'))).toBe(true);
-    });
-
-    it('TimelineEntry JSON includes source "voice"', () => {
-      const { container } = render(<App />);
-      const preContents = Array.from(container.querySelectorAll('pre')).map((p) => p.textContent ?? '');
-      expect(preContents.some((text) => text.includes('"source": "voice"'))).toBe(true);
-    });
-
-    it('TimelineEntry JSON includes tags', () => {
-      const { container } = render(<App />);
-      const preContents = Array.from(container.querySelectorAll('pre')).map((p) => p.textContent ?? '');
-      expect(preContents.some((text) => text.includes('architecture') && text.includes('planning'))).toBe(true);
-    });
-
-    it('TimelineEntry JSON includes userId', () => {
-      const { container } = render(<App />);
-      const preContents = Array.from(container.querySelectorAll('pre')).map((p) => p.textContent ?? '');
-      expect(preContents.some((text) => text.includes('"userId": "user-1"'))).toBe(true);
-    });
+  it('shows empty missed-detail placeholder by default', () => {
+    render(<App />);
+    expect(screen.getByText('No contradictions found yet.')).toBeInTheDocument();
   });
 
-  describe('VoiceCaptureSession section', () => {
-    it('renders a "VoiceCaptureSession" section heading', () => {
-      render(<App />);
-      expect(screen.getByRole('heading', { level: 2, name: 'VoiceCaptureSession' })).toBeInTheDocument();
-    });
-
-    it('VoiceCaptureSession JSON includes id and state', () => {
-      const { container } = render(<App />);
-      const preContents = Array.from(container.querySelectorAll('pre')).map((p) => p.textContent ?? '');
-      expect(preContents.some((text) => text.includes('"id": "voice-session-1"'))).toBe(true);
-      expect(preContents.some((text) => text.includes('"state": "capturing"'))).toBe(true);
-    });
-
-    it('VoiceCaptureSession JSON includes null endedAt', () => {
-      const { container } = render(<App />);
-      const preContents = Array.from(container.querySelectorAll('pre')).map((p) => p.textContent ?? '');
-      expect(preContents.some((text) => text.includes('"endedAt": null'))).toBe(true);
-    });
-
-    it('VoiceCaptureSession JSON includes language "en-US"', () => {
-      const { container } = render(<App />);
-      const preContents = Array.from(container.querySelectorAll('pre')).map((p) => p.textContent ?? '');
-      expect(preContents.some((text) => text.includes('"language": "en-US"'))).toBe(true);
-    });
-  });
-
-  describe('Insight + DailyReviewSession section', () => {
-    it('renders the "Insight + DailyReviewSession" section heading', () => {
-      render(<App />);
-      expect(screen.getByRole('heading', { level: 2, name: 'Insight + DailyReviewSession' })).toBeInTheDocument();
-    });
-
-    it('Insight JSON includes type "pattern" and confidence', () => {
-      const { container } = render(<App />);
-      const preContents = Array.from(container.querySelectorAll('pre')).map((p) => p.textContent ?? '');
-      expect(preContents.some((text) => text.includes('"type": "pattern"'))).toBe(true);
-      expect(preContents.some((text) => text.includes('"confidence": 0.91'))).toBe(true);
-    });
-
-    it('Insight JSON includes summary text', () => {
-      const { container } = render(<App />);
-      const preContents = Array.from(container.querySelectorAll('pre')).map((p) => p.textContent ?? '');
-      expect(
-        preContents.some((text) => text.includes('Planning work is concentrated in the first half of the day.'))
-      ).toBe(true);
-    });
-
-    it('DailyReviewSession JSON includes status "in_progress"', () => {
-      const { container } = render(<App />);
-      const preContents = Array.from(container.querySelectorAll('pre')).map((p) => p.textContent ?? '');
-      expect(preContents.some((text) => text.includes('"status": "in_progress"'))).toBe(true);
-    });
-
-    it('DailyReviewSession JSON includes null completedAt', () => {
-      const { container } = render(<App />);
-      const preContents = Array.from(container.querySelectorAll('pre')).map((p) => p.textContent ?? '');
-      expect(preContents.some((text) => text.includes('"completedAt": null'))).toBe(true);
-    });
-  });
-
-  describe('section count', () => {
-    it('renders exactly three content sections', () => {
-      const { container } = render(<App />);
-      const sections = container.querySelectorAll('section');
-      expect(sections).toHaveLength(3);
-    });
-
-    it('renders exactly three <pre> elements (one per section)', () => {
-      const { container } = render(<App />);
-      const pres = container.querySelectorAll('pre');
-      expect(pres).toHaveLength(3);
-    });
+  it('renders starter voice timeline content in JSON preview', () => {
+    const { container } = render(<App />);
+    const preContents = Array.from(container.querySelectorAll('pre')).map((pre) => pre.textContent ?? '');
+    expect(preContents.some((text) => text.includes('"source": "voice"'))).toBe(true);
+    expect(preContents.some((text) => text.includes('"id": "voice-session-1"'))).toBe(true);
   });
 });

--- a/apps/web/src/lib/screenshotBridge.ts
+++ b/apps/web/src/lib/screenshotBridge.ts
@@ -1,0 +1,21 @@
+import type { ScreenshotEvent } from '@daily-timeline/types';
+
+const BRIDGE_EVENT = 'daily-timeline:screenshot';
+
+export type ScreenshotBridgeHandler = (event: ScreenshotEvent) => void;
+
+export function listenForScreenshotEvents(handler: ScreenshotBridgeHandler): () => void {
+  const listener = (event: Event): void => {
+    const custom = event as CustomEvent<ScreenshotEvent>;
+    if (custom.detail) {
+      handler(custom.detail);
+    }
+  };
+
+  window.addEventListener(BRIDGE_EVENT, listener as EventListener);
+  return () => window.removeEventListener(BRIDGE_EVENT, listener as EventListener);
+}
+
+export function emitScreenshotEvent(event: ScreenshotEvent): void {
+  window.dispatchEvent(new CustomEvent<ScreenshotEvent>(BRIDGE_EVENT, { detail: event }));
+}

--- a/packages/types/src/__tests__/index.test.ts
+++ b/packages/types/src/__tests__/index.test.ts
@@ -200,6 +200,65 @@ describe('ScreenshotEvent', () => {
     expect(Array.isArray(event.linkedTimelineEntryIds)).toBe(true);
     expect(event.linkedTimelineEntryIds).toHaveLength(2);
   });
+
+  it('entities, taskClues and anomalies are all arrays', () => {
+    const event: ScreenshotEvent = {
+      id: 'arrays-check',
+      imageUrl: 'https://example.com/img.png',
+      capturedAt: '2024-01-01T00:00:00.000Z',
+      createdAt: '2024-01-01T00:00:01.000Z',
+      windowTitle: 'Editor',
+      inferredTask: 'Working on deploy workflow',
+      ocrText: 'some text',
+      entities: ['VSCode', 'Terminal'],
+      taskClues: ['deploy', 'review'],
+      anomalies: ['error', 'warning'],
+      linkedTimelineEntryIds: [],
+    };
+    expect(Array.isArray(event.entities)).toBe(true);
+    expect(Array.isArray(event.taskClues)).toBe(true);
+    expect(Array.isArray(event.anomalies)).toBe(true);
+    expect(event.entities).toHaveLength(2);
+    expect(event.taskClues).toHaveLength(2);
+    expect(event.anomalies).toHaveLength(2);
+  });
+
+  it('imageUrl is stored as a string field on the event', () => {
+    const event: ScreenshotEvent = {
+      id: 'url-check',
+      imageUrl: 'https://storage.example.com/screenshots/abc123.png',
+      capturedAt: '2024-01-01T00:00:00.000Z',
+      createdAt: '2024-01-01T00:00:01.000Z',
+      windowTitle: null,
+      inferredTask: null,
+      ocrText: null,
+      entities: [],
+      taskClues: [],
+      anomalies: [],
+      linkedTimelineEntryIds: [],
+    };
+    expect(typeof event.imageUrl).toBe('string');
+    expect(event.imageUrl).toBe('https://storage.example.com/screenshots/abc123.png');
+  });
+
+  it('createdAt and capturedAt are separate timestamp fields', () => {
+    const event: ScreenshotEvent = {
+      id: 'timestamps',
+      imageUrl: 'https://example.com/img.png',
+      capturedAt: '2024-01-15T09:00:00.000Z',
+      createdAt: '2024-01-15T09:00:05.000Z',
+      windowTitle: null,
+      inferredTask: null,
+      ocrText: null,
+      entities: [],
+      taskClues: [],
+      anomalies: [],
+      linkedTimelineEntryIds: [],
+    };
+    expect(event.capturedAt).toBe('2024-01-15T09:00:00.000Z');
+    expect(event.createdAt).toBe('2024-01-15T09:00:05.000Z');
+    expect(event.capturedAt).not.toBe(event.createdAt);
+  });
 });
 
 describe('Insight', () => {

--- a/packages/types/src/__tests__/index.test.ts
+++ b/packages/types/src/__tests__/index.test.ts
@@ -143,51 +143,62 @@ describe('ScreenshotEvent', () => {
   it('accepts a fully populated ScreenshotEvent', () => {
     const event: ScreenshotEvent = {
       id: 'screenshot-1',
-      timelineEntryId: 'entry-1',
+      imageUrl: 'https://storage.example.com/screenshots/1.png',
       capturedAt: '2024-01-15T09:00:00.000Z',
-      url: 'https://storage.example.com/screenshots/1.png',
-      width: 1920,
-      height: 1080,
-      appContext: 'VSCode',
-      extractedText: 'function hello() {}',
+      createdAt: '2024-01-15T09:00:05.000Z',
+      windowTitle: 'VSCode - timeline project',
+      inferredTask: 'Implement screenshot ingestion flow',
+      ocrText: 'function hello() {}',
+      entities: ['VSCode', 'timeline'],
+      taskClues: ['TODO', 'timeline'],
+      anomalies: ['Unexpected error modal'],
+      linkedTimelineEntryIds: ['entry-1'],
     };
 
     expect(event.id).toBe('screenshot-1');
-    expect(event.width).toBe(1920);
-    expect(event.height).toBe(1080);
-    expect(event.appContext).toBe('VSCode');
-    expect(event.extractedText).toBe('function hello() {}');
+    expect(event.windowTitle).toContain('VSCode');
+    expect(event.inferredTask).toContain('screenshot ingestion');
+    expect(event.ocrText).toBe('function hello() {}');
+    expect(event.entities).toEqual(['VSCode', 'timeline']);
+    expect(event.linkedTimelineEntryIds).toEqual(['entry-1']);
   });
 
-  it('accepts null for optional appContext and extractedText', () => {
+  it('accepts null for optional windowTitle, inferredTask and ocrText', () => {
     const event: ScreenshotEvent = {
       id: 'screenshot-2',
-      timelineEntryId: 'entry-1',
+      imageUrl: 'https://storage.example.com/screenshots/2.png',
       capturedAt: '2024-01-15T09:00:00.000Z',
-      url: 'https://storage.example.com/screenshots/2.png',
-      width: 800,
-      height: 600,
-      appContext: null,
-      extractedText: null,
+      createdAt: '2024-01-15T09:00:05.000Z',
+      windowTitle: null,
+      inferredTask: null,
+      ocrText: null,
+      entities: [],
+      taskClues: [],
+      anomalies: [],
+      linkedTimelineEntryIds: [],
     };
 
-    expect(event.appContext).toBeNull();
-    expect(event.extractedText).toBeNull();
+    expect(event.windowTitle).toBeNull();
+    expect(event.inferredTask).toBeNull();
+    expect(event.ocrText).toBeNull();
   });
 
-  it('width and height are numeric', () => {
+  it('linkedTimelineEntryIds is an array of entry IDs', () => {
     const event: ScreenshotEvent = {
       id: 'x',
-      timelineEntryId: 'y',
+      imageUrl: 'https://example.com/img.png',
       capturedAt: '2024-01-01T00:00:00.000Z',
-      url: 'https://example.com/img.png',
-      width: 1024,
-      height: 768,
-      appContext: null,
-      extractedText: null,
+      createdAt: '2024-01-01T00:00:01.000Z',
+      windowTitle: null,
+      inferredTask: null,
+      ocrText: null,
+      entities: ['Terminal'],
+      taskClues: ['build'],
+      anomalies: [],
+      linkedTimelineEntryIds: ['entry-1', 'entry-2'],
     };
-    expect(typeof event.width).toBe('number');
-    expect(typeof event.height).toBe('number');
+    expect(Array.isArray(event.linkedTimelineEntryIds)).toBe(true);
+    expect(event.linkedTimelineEntryIds).toHaveLength(2);
   });
 });
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -21,13 +21,16 @@ export interface VoiceCaptureSession {
 
 export interface ScreenshotEvent {
   id: string;
-  timelineEntryId: string;
+  imageUrl: string;
   capturedAt: string;
-  url: string;
-  width: number;
-  height: number;
-  appContext: string | null;
-  extractedText: string | null;
+  createdAt: string;
+  windowTitle: string | null;
+  inferredTask: string | null;
+  ocrText: string | null;
+  entities: string[];
+  taskClues: string[];
+  anomalies: string[];
+  linkedTimelineEntryIds: string[];
 }
 
 export interface Insight {


### PR DESCRIPTION
### Motivation
- Capture screenshots as first-class timeline events and surface signals that can contradict or enrich earlier entries. 
- Provide server-side ingestion and enrichment so images are stored, analyzed for OCR/entities/anomalies, and cross-linked to the rolling timeline. 
- Enable near-real-time ingestion from a frontend/desktop bridge so screenshots can appear in the UI and surface “possible missed detail” cards.

### Description
- Introduced an enriched `ScreenshotEvent` shape in `packages/types` with fields like `imageUrl`, `capturedAt`, `createdAt`, `windowTitle`, `inferredTask`, `ocrText`, `entities`, `taskClues`, `anomalies`, and `linkedTimelineEntryIds`. 
- Added a lightweight vision analysis module `apps/api/src/services/vision/` exposing `extractOcrText` and `analyzeScreenshot` to infer OCR-like text, entities, task clues, anomalies, and an `inferredTask`. 
- Implemented screenshot ingestion under `apps/api/src/services/screenshots/` including `schema.ts` (Zod validation), `storage.ts` (storage abstraction + in-memory impl), `linker.ts` (`linkScreenshotToTimeline`), `service.ts` (`ingestScreenshotEvent` orchestration), and `routes.ts` (`GET /screenshots/events` and `POST /screenshots/events`). 
- Wired the ingestion routes into the API (`apps/api/src/server.ts`) and added a frontend bridge `apps/web/src/lib/screenshotBridge.ts` plus UI integration in `apps/web/src/App.tsx` to poll/listen for events and render “possible missed detail” cards. 

### Testing
- Ran `npx vitest run packages/types/src/__tests__/index.test.ts apps/api/src/services/__tests__/screenshot-pipeline.test.ts` and both test files passed (24 tests total). 
- Attempting the full test run (`npm test`) surfaced unrelated suite failures in this environment due to missing workspace app dependencies and environment constraints (errors included missing local packages like `fastify` and `@testing-library/react`, and many server-side test modules importing project-level modules). 
- Attempting `npm install` inside `apps/api` failed because the workspace package `@daily-timeline/types@0.1.0` is not available from the npm registry in this environment, which blocks running the full app-level tests here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d23d11a5ac833185d55794a4800d5f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Screenshot capture and ingestion with validation and error feedback on invalid uploads
  * Automatic OCR, task inference, entity extraction, and anomaly detection producing “missed detail” insights
  * Automatic linking of screenshots to timeline entries and a live screenshot event stream in the UI

* **Bug Fixes / Improvements**
  * More reliable screenshot polling and UI updates with de-duplication and stable event shapes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->